### PR TITLE
Track CRAN comments and fix README

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,5 @@
 ^scripts$
 cache_test_data
 ^README\.Rmd$
+^cran-comments\.md$
+^CRAN-RELEASE$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Authors@R: c(person("Adam", "Blake", email = "theadamattack@gmail.com", role = "
              person("Jim", "Stigler", email = "jstigler@gmail.com", role = c("cre", "aut")))
 Encoding: UTF-8
 LazyData: yes
-Description: Produces ANOVA tables in the format used by Judd, McClelland, and Ryan (2017, ISBN:978-1138819832) in their introductory textbook, Data Analysis. This includes proportional reduction in error and formatting to improve ease the transition between the book and R.
+Description: Produces ANOVA tables in the format used by Judd, McClelland, and Ryan (2017, ISBN: 978-1138819832) in their introductory textbook, Data Analysis. This includes proportional reduction in error and formatting to improve ease the transition between the book and R.
 License: GPL-3
 Depends: R (>= 2.10)
 Suggests: 

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ set.seed(123)
 
 # supernova <img src="man/figures/logo.png" width="40%" align="right" />
 
-The goal of `supernova` is to create ANOVA tables in the format used by Judd, McClelland, and Ryan (2017, ISBN:978-1138819832) in their introductory textbook, *Data Analysis: A Model Comparison Approach to Regression, ANOVA, and Beyond* [(book website)](http://www.dataanalysisbook.com/index.html).\* These tables include proportional reduction in error, a useful measure for teaching the underlying concepts of ANOVA and regression, and formatting to ease the transition between the book and R. 
+The goal of `supernova` is to create ANOVA tables in the format used by Judd, McClelland, and Ryan (2017, ISBN: 978-1138819832) in their introductory textbook, *Data Analysis: A Model Comparison Approach to Regression, ANOVA, and Beyond* [(book website)](http://www.dataanalysisbook.com/index.html).\* These tables include proportional reduction in error, a useful measure for teaching the underlying concepts of ANOVA and regression, and formatting to ease the transition between the book and R. 
 
 *\* Note: we are NOT affiliated with the authors or their institution.*
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # supernova <img src="man/figures/logo.png" width="40%" align="right" />
 
 The goal of `supernova` is to create ANOVA tables in the format used by
-Judd, McClelland, and Ryan (2017, <ISBN:978-1138819832>) in their
+Judd, McClelland, and Ryan (2017, ISBN: 978-1138819832) in their
 introductory textbook, *Data Analysis: A Model Comparison Approach to
 Regression, ANOVA, and Beyond* [(book
 website)](http://www.dataanalysisbook.com/index.html).\* These tables

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,14 @@
+Only comment by Uwe Ligges on previous submission:
+
+> Found the following possibly invalid URLs:
+>  URL: ISBN:978-1138819832
+> From: README.md
+> Message: Invalid URI scheme
+>
+> Please do not use URL markup for ISBN numbers.
+
+To fix, we made sure the ISBN is formatted as plaintext in the generated file.
+
 ## Test environments
 
 * local install, R 3.6.1

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,18 @@
+## Test environments
+
+* local install, R 3.6.1
+* win-builder
+* r-hub
+  - Windows Server 2008 R2 SP1, R-devel, 32/64 bit
+  - Ubuntu Linux 16.04 LTS, R-release, GCC
+  - Fedora Linux, R-devel, clang, gfortran
+
+
+## R CMD check results
+
+0 errors | 0 warnings | 0 notes
+
+
+## Reverse dependencies
+
+No known reverse dependencies.


### PR DESCRIPTION
### Track CRAN comments

We have to submit comments on the upload to CRAN every time we submit a package. Tracking these makes it easier to remember what to write and include in these comments, and it is suggested that they are tracked in git

### Remove ISBN link in README

When the ISBN is written as ISBN:978-1138819832 (no space after the colon) knitting the .Rmd file converts it to <ISBN:978-1138819832>. Add a space after the colon to ensure it remains plaintext in the output file.
