### PR TITLE
Add version requirement for pillar

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Imports:
     rlang,
     stringr,
     vctrs,
-    pillar,
+    pillar (>= 1.5.0),
     methods,
     backports
 RoxygenNote: 7.1.1


### PR DESCRIPTION
This fixes a (probably) rare bug where user with an outdated version of pillar could not attach the package because `tbl_sum` was not introduced yet (see: https://twitter.com/dom_muller/status/1418846635229073415).


R CMD CHECK fails on my computer but I don't think this has to do with the PR. 
[00check.log](https://github.com/UCLATALL/supernova/files/6872129/00check.log)
